### PR TITLE
Test to verify that when subtype is not passed to message types it can still be deserialized

### DIFF
--- a/src/Tests/With_base_but_without_concrete.cs
+++ b/src/Tests/With_base_but_without_concrete.cs
@@ -1,0 +1,45 @@
+﻿using System.IO;
+using System.Linq;
+using NServiceBus;
+using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+using NServiceBus.Newtonsoft.Json;
+using NUnit.Framework;
+
+[TestFixture]
+public class With_base_type_but_without_sub_type_in_message_types
+{
+    [Test]
+    public void Deserialize()
+    {
+        var messageMapper = new MessageMapper();
+        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null);
+        var messageTypes = new[]
+        {
+            typeof(ISomeBaseMessage)
+        };
+        messageMapper.Initialize(messageTypes.Union(new[]
+        {
+            typeof(ISomeMessage)
+        }));
+        var message = messageMapper.CreateInstance<ISomeMessage>(x => x.SomeProperty = "test");
+        using (var stream = new MemoryStream())
+        {
+            serializer.Serialize(message, stream);
+
+            stream.Position = 0;
+            var result = (ISomeBaseMessage)serializer.Deserialize(stream, messageTypes)[0];
+
+            Assert.AreEqual("test", result.SomeProperty);
+        }
+
+    }
+
+    public interface ISomeMessage : ISomeBaseMessage
+    {
+    }
+
+    public interface ISomeBaseMessage : IMessage
+    {
+        string SomeProperty { get; set; }
+    }
+}


### PR DESCRIPTION
Test to verify that when subtype is not passed to message types it can still be deserialized (in case with unobtrusive when you only handle the base type)

Should cover test removed in core [here](https://github.com/Particular/NServiceBus/pull/4836/commits/27e63974f8a78b1fe4adb211b2e70f54aa3a7574)