### PR TITLE
Undo BOM changes

### DIFF
--- a/src/NServiceBus.Newtonsoft.Json/JsonMessageSerializer.cs
+++ b/src/NServiceBus.Newtonsoft.Json/JsonMessageSerializer.cs
@@ -16,7 +16,6 @@ namespace NServiceBus.Newtonsoft.Json
         Func<Stream, JsonReader> readerCreator;
         Func<Stream, JsonWriter> writerCreator;
         NewtonSerializer jsonSerializer;
-        static readonly Encoding utf8NoBOM = new UTF8Encoding(false, false);
 
         public JsonMessageSerializer(
             IMessageMapper messageMapper,
@@ -34,7 +33,7 @@ namespace NServiceBus.Newtonsoft.Json
 
             this.writerCreator = writerCreator ?? (stream =>
             {
-                var streamWriter = new StreamWriter(stream, utf8NoBOM);
+                var streamWriter = new StreamWriter(stream, Encoding.UTF8);
                 return new JsonTextWriter(streamWriter)
                 {
                     Formatting = Formatting.None

--- a/src/Tests/When_serializing_a_message.cs
+++ b/src/Tests/When_serializing_a_message.cs
@@ -1,5 +1,7 @@
-﻿using System.IO;
+﻿using System;
+using System.IO;
 using System.Text;
+using Newtonsoft.Json;
 using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
 using NServiceBus.Newtonsoft.Json;
 using NUnit.Framework;
@@ -7,12 +9,44 @@ using NUnit.Framework;
 [TestFixture]
 public class When_serializing_a_message
 {
-
     [Test]
-    public void Should_not_emit_UTF8_BOM()
+    public void Should_emit_UTF8_BOM_by_default()
     {
         var messageMapper = new MessageMapper();
         var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null);
+        var message = new SimpleMessage();
+        using (var stream = new MemoryStream())
+        {
+            serializer.Serialize(message, stream);
+
+            stream.Position = 0;
+
+            var result = stream.ToArray();
+            var utf8bom = new UTF8Encoding(true).GetPreamble();
+
+            for (var i = 0; i < utf8bom.Length; i++)
+            {
+                Assert.AreEqual(utf8bom[i], result[i]);
+            }
+        }
+    }
+    
+    [Test]
+    public void Should_not_emit_UTF8_BOM_if_configured_not_to()
+    {
+        var messageMapper = new MessageMapper();
+
+        Func<Stream, JsonWriter> writerCreator = stream =>
+        {
+            var streamWriter = new StreamWriter(stream, new UTF8Encoding(false, false));
+            return new JsonTextWriter(streamWriter)
+            {
+                Formatting = Formatting.None
+            };
+        };
+
+        var serializer = new JsonMessageSerializer(messageMapper, null, writerCreator, null, null);
+        
         var message = new SimpleMessage();
         using (var stream = new MemoryStream())
         {
@@ -29,6 +63,7 @@ public class When_serializing_a_message
             }
         }
     }
+
     public class SimpleMessage
     {
         public string SomeProperty { get; set; }


### PR DESCRIPTION
Undo hotfix 2.2.1 by reverting changes. BOM will be emitted by default as before and if required, the serializer can be configured to omit it.