### PR TITLE
Log warning when using the default json settings

### DIFF
--- a/src/NServiceBus.Newtonsoft.Json/JsonMessageSerializer.cs
+++ b/src/NServiceBus.Newtonsoft.Json/JsonMessageSerializer.cs
@@ -6,8 +6,9 @@
     using System.Linq;
     using System.Text;
     using global::Newtonsoft.Json;
-    using NServiceBus.MessageInterfaces;
-    using NServiceBus.Serialization;
+    using Logging;
+    using MessageInterfaces;
+    using Serialization;
     using NewtonSerializer = global::Newtonsoft.Json.JsonSerializer;
 
     class JsonMessageSerializer : IMessageSerializer
@@ -26,10 +27,11 @@
         {
             this.messageMapper = messageMapper;
 
-            settings ??= new JsonSerializerSettings
+            if (settings == null)
             {
-                TypeNameHandling = TypeNameHandling.Auto
-            };
+                settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto };
+                log.Warn($"The default {nameof(JsonSerializerSettings)} for NServiceBus.Newtonsoft.Json use TypeNameHandling.Auto for backwards compatibility. This is a potential security vulnerability and it is recommended to use TypeNameHandling.None if possible. To disable this warning, provide a custom {nameof(JsonSerializerSettings)} instance to 'endpointConfiguration.UseSerialization<NewtonsoftSerializer>().Settings'.");
+            }
 
             this.writerCreator = writerCreator ?? (stream =>
             {
@@ -161,6 +163,7 @@
                 }
             }
         }
-    }
 
+        static ILog log = LogManager.GetLogger<JsonMessageSerializer>();
+    }
 }

--- a/src/NServiceBus.Newtonsoft.Json/JsonMessageSerializer.cs
+++ b/src/NServiceBus.Newtonsoft.Json/JsonMessageSerializer.cs
@@ -30,7 +30,7 @@
             if (settings == null)
             {
                 settings = new JsonSerializerSettings { TypeNameHandling = TypeNameHandling.Auto };
-                log.Warn($"The default {nameof(JsonSerializerSettings)} for NServiceBus.Newtonsoft.Json use TypeNameHandling.Auto for backwards compatibility. This is a potential security vulnerability and it is recommended to use TypeNameHandling.None if possible. To disable this warning, provide a custom {nameof(JsonSerializerSettings)} instance to 'endpointConfiguration.UseSerialization<NewtonsoftSerializer>().Settings'.");
+                log.Warn($"The default {nameof(JsonSerializerSettings)} for NServiceBus.Newtonsoft.Json use TypeNameHandling.Auto for backwards compatibility. This is a potential security vulnerability and it is recommended to use TypeNameHandling.None if possible. To disable this warning, provide a custom {nameof(JsonSerializerSettings)} instance to 'endpointConfiguration.UseSerialization<NewtonsoftSerializer>().Settings'. Refer to the Json.NET serializer documentation at https://docs.particular.net/ for further details.");
             }
 
             this.writerCreator = writerCreator ?? (stream =>


### PR DESCRIPTION
Small change that brings more attention to users about the [default `TypeNameHandling` settings](https://docs.particular.net/nservicebus/serialization/newtonsoft#typenamehandling) via logging a warning when running with the default settings (using `TypeNameHandling.Auto`). This log warning disappears when the user provides a custom setting that either explicitly enables `TypeNameHandling.Auto` or uses the default `TypeNameHandling` setting which is `None`. Since this doesn't change the default behavior itself, this is not a breaking change unless the user makes the explicit decision to change the settings.

I'd prefer to not call logging in the ctor of the settings but I think it's acceptable in this case given all the default handling is happening in the `JsonMessageSerializer` ctor.