### PR TITLE
Introduce new Serializer definition with safe type name handling

### DIFF
--- a/src/JsonMessageSerializerTest.TestInterfaces.txt
+++ b/src/JsonMessageSerializerTest.TestInterfaces.txt
@@ -1,0 +1,1 @@
+﻿{"Data":"Vwo1G0YwhnrlyT/JcVN06/OLKoBtJmo=","S":"kalle","I":42,"B":{"BString":"BOO","C":{"Cstr":"COO"}}}

--- a/src/JsonMessageSerializerTest.TestInterfaces.txt
+++ b/src/JsonMessageSerializerTest.TestInterfaces.txt
@@ -1,1 +1,1 @@
-﻿{"Data":"Vwo1G0YwhnrlyT/JcVN06/OLKoBtJmo=","S":"kalle","I":42,"B":{"BString":"BOO","C":{"Cstr":"COO"}}}
+﻿{"Data":"vYACEf55C+wOHWitMt5TPsyLzHPMMcQ=","S":"kalle","I":42,"B":{"BString":"BOO","C":{"Cstr":"COO"}}}

--- a/src/NServiceBus.Newtonsoft.Json/FodyWeavers.xml
+++ b/src/NServiceBus.Newtonsoft.Json/FodyWeavers.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Weavers GenerateXsd="false">
+  <Obsolete HideObsoleteMembers="never" />
+</Weavers>

--- a/src/NServiceBus.Newtonsoft.Json/NServiceBus.Newtonsoft.Json.csproj
+++ b/src/NServiceBus.Newtonsoft.Json/NServiceBus.Newtonsoft.Json.csproj
@@ -10,7 +10,7 @@
     <PackageReference Include="Fody" Version="6.6.3" PrivateAssets="All" />
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="[13.0.1, 14.0.0)" />
-    <PackageReference Include="NServiceBus" Version="[7.0.0, 8.0.0)" />    
+    <PackageReference Include="NServiceBus" Version="[7.0.0, 8.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.Newtonsoft.Json/NServiceBus.Newtonsoft.Json.csproj
+++ b/src/NServiceBus.Newtonsoft.Json/NServiceBus.Newtonsoft.Json.csproj
@@ -7,8 +7,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Fody" Version="6.6.3" PrivateAssets="All" />
+    <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
     <PackageReference Include="Newtonsoft.Json" Version="[13.0.1, 14.0.0)" />
-    <PackageReference Include="NServiceBus" Version="[7.0.0, 8.0.0)" />
+    <PackageReference Include="NServiceBus" Version="[7.0.0, 8.0.0)" />    
     <PackageReference Include="Particular.Packaging" Version="2.0.0" PrivateAssets="All" />
   </ItemGroup>
 

--- a/src/NServiceBus.Newtonsoft.Json/NewtonsoftConfigurationExtensions.cs
+++ b/src/NServiceBus.Newtonsoft.Json/NewtonsoftConfigurationExtensions.cs
@@ -19,9 +19,9 @@
         /// <param name="config">The <see cref="SerializationExtensions{T}"/> instance.</param>
         /// <param name="readerCreator">A delegate that creates a <see cref="JsonReader"/> for a <see cref="Stream"/>.</param>
         [ObsoleteEx(
+        Message = "Use the equivalent method on NewtonsoftJsonSerializer instead.",
         TreatAsErrorFromVersion = "3.0",
-        RemoveInVersion = "4.0",
-        ReplacementTypeOrMember = nameof(NewtonsoftJsonSerializer))]
+        RemoveInVersion = "4.0")]
         public static void ReaderCreator(this SerializationExtensions<NewtonsoftSerializer> config, Func<Stream, JsonReader> readerCreator)
         {
             Guard.AgainstNull(config, nameof(config));
@@ -52,9 +52,9 @@
         /// <param name="config">The <see cref="SerializationExtensions{T}"/> instance.</param>
         /// <param name="writerCreator">A delegate that creates a <see cref="JsonWriter"/> for a <see cref="Stream"/>.</param>
         [ObsoleteEx(
+        Message = "Use the equivalent method on NewtonsoftJsonSerializer instead.",
         TreatAsErrorFromVersion = "3.0",
-        RemoveInVersion = "4.0",
-        ReplacementTypeOrMember = nameof(NewtonsoftJsonSerializer))]
+        RemoveInVersion = "4.0")]
         public static void WriterCreator(this SerializationExtensions<NewtonsoftSerializer> config, Func<Stream, JsonWriter> writerCreator)
         {
             Guard.AgainstNull(config, nameof(config));
@@ -85,9 +85,9 @@
         /// <param name="config">The <see cref="SerializationExtensions{T}"/> instance.</param>
         /// <param name="settings">The <see cref="JsonSerializerSettings"/> to use.</param>
         [ObsoleteEx(
+        Message = "Use the equivalent method on NewtonsoftJsonSerializer instead.",
         TreatAsErrorFromVersion = "3.0",
-        RemoveInVersion = "4.0",
-        ReplacementTypeOrMember = nameof(NewtonsoftJsonSerializer))]
+        RemoveInVersion = "4.0")]
         public static void Settings(this SerializationExtensions<NewtonsoftSerializer> config, JsonSerializerSettings settings)
         {
             Guard.AgainstNull(config, nameof(config));
@@ -122,9 +122,9 @@
         /// <param name="config">The <see cref="SerializationExtensions{T}"/> instance.</param>
         /// <param name="contentTypeKey">The content type key to use.</param>
         [ObsoleteEx(
+        Message = "Use the equivalent method on NewtonsoftJsonSerializer instead.",
         TreatAsErrorFromVersion = "3.0",
-        RemoveInVersion = "4.0",
-        ReplacementTypeOrMember = nameof(NewtonsoftJsonSerializer))]
+        RemoveInVersion = "4.0")]
         public static void ContentTypeKey(this SerializationExtensions<NewtonsoftSerializer> config, string contentTypeKey)
         {
             Guard.AgainstNull(config, nameof(config));

--- a/src/NServiceBus.Newtonsoft.Json/NewtonsoftConfigurationExtensions.cs
+++ b/src/NServiceBus.Newtonsoft.Json/NewtonsoftConfigurationExtensions.cs
@@ -18,7 +18,23 @@
         /// </summary>
         /// <param name="config">The <see cref="SerializationExtensions{T}"/> instance.</param>
         /// <param name="readerCreator">A delegate that creates a <see cref="JsonReader"/> for a <see cref="Stream"/>.</param>
+        [ObsoleteEx(
+        TreatAsErrorFromVersion = "3.0",
+        RemoveInVersion = "4.0",
+        ReplacementTypeOrMember = nameof(NewtonsoftJsonSerializer))]
         public static void ReaderCreator(this SerializationExtensions<NewtonsoftSerializer> config, Func<Stream, JsonReader> readerCreator)
+        {
+            Guard.AgainstNull(config, nameof(config));
+            Guard.AgainstNull(readerCreator, nameof(readerCreator));
+            config.GetSettings().Set("NServiceBus.Newtonsoft.Json.ReaderCreator", readerCreator);
+        }
+
+        /// <summary>
+        /// Configures the <see cref="JsonReader"/> creator of JSON stream.
+        /// </summary>
+        /// <param name="config">The <see cref="SerializationExtensions{T}"/> instance.</param>
+        /// <param name="readerCreator">A delegate that creates a <see cref="JsonReader"/> for a <see cref="Stream"/>.</param>
+        public static void ReaderCreator(this SerializationExtensions<NewtonsoftJsonSerializer> config, Func<Stream, JsonReader> readerCreator)
         {
             Guard.AgainstNull(config, nameof(config));
             Guard.AgainstNull(readerCreator, nameof(readerCreator));
@@ -35,7 +51,23 @@
         /// </summary>
         /// <param name="config">The <see cref="SerializationExtensions{T}"/> instance.</param>
         /// <param name="writerCreator">A delegate that creates a <see cref="JsonWriter"/> for a <see cref="Stream"/>.</param>
+        [ObsoleteEx(
+        TreatAsErrorFromVersion = "3.0",
+        RemoveInVersion = "4.0",
+        ReplacementTypeOrMember = nameof(NewtonsoftJsonSerializer))]
         public static void WriterCreator(this SerializationExtensions<NewtonsoftSerializer> config, Func<Stream, JsonWriter> writerCreator)
+        {
+            Guard.AgainstNull(config, nameof(config));
+            Guard.AgainstNull(writerCreator, nameof(writerCreator));
+            config.GetSettings().Set("NServiceBus.Newtonsoft.Json.WriterCreator", writerCreator);
+        }
+
+        /// <summary>
+        /// Configures the <see cref="JsonWriter"/> creator of JSON stream.
+        /// </summary>
+        /// <param name="config">The <see cref="SerializationExtensions{T}"/> instance.</param>
+        /// <param name="writerCreator">A delegate that creates a <see cref="JsonWriter"/> for a <see cref="Stream"/>.</param>
+        public static void WriterCreator(this SerializationExtensions<NewtonsoftJsonSerializer> config, Func<Stream, JsonWriter> writerCreator)
         {
             Guard.AgainstNull(config, nameof(config));
             Guard.AgainstNull(writerCreator, nameof(writerCreator));
@@ -52,7 +84,23 @@
         /// </summary>
         /// <param name="config">The <see cref="SerializationExtensions{T}"/> instance.</param>
         /// <param name="settings">The <see cref="JsonSerializerSettings"/> to use.</param>
+        [ObsoleteEx(
+        TreatAsErrorFromVersion = "3.0",
+        RemoveInVersion = "4.0",
+        ReplacementTypeOrMember = nameof(NewtonsoftJsonSerializer))]
         public static void Settings(this SerializationExtensions<NewtonsoftSerializer> config, JsonSerializerSettings settings)
+        {
+            Guard.AgainstNull(config, nameof(config));
+            Guard.AgainstNull(settings, nameof(settings));
+            config.GetSettings().Set("NServiceBus.Newtonsoft.Json.Settings", settings);
+        }
+
+        /// <summary>
+        /// Configures the <see cref="JsonSerializerSettings"/> to use.
+        /// </summary>
+        /// <param name="config">The <see cref="SerializationExtensions{T}"/> instance.</param>
+        /// <param name="settings">The <see cref="JsonSerializerSettings"/> to use.</param>
+        public static void Settings(this SerializationExtensions<NewtonsoftJsonSerializer> config, JsonSerializerSettings settings)
         {
             Guard.AgainstNull(config, nameof(config));
             Guard.AgainstNull(settings, nameof(settings));
@@ -73,7 +121,27 @@
         /// </remarks>
         /// <param name="config">The <see cref="SerializationExtensions{T}"/> instance.</param>
         /// <param name="contentTypeKey">The content type key to use.</param>
+        [ObsoleteEx(
+        TreatAsErrorFromVersion = "3.0",
+        RemoveInVersion = "4.0",
+        ReplacementTypeOrMember = nameof(NewtonsoftJsonSerializer))]
         public static void ContentTypeKey(this SerializationExtensions<NewtonsoftSerializer> config, string contentTypeKey)
+        {
+            Guard.AgainstNull(config, nameof(config));
+            Guard.AgainstNullOrEmpty(contentTypeKey, nameof(contentTypeKey));
+            config.GetSettings().Set("NServiceBus.Newtonsoft.Json.ContentTypeKey", contentTypeKey);
+        }
+
+        /// <summary>
+        /// Configures string to use for <see cref="Headers.ContentType"/> headers.
+        /// </summary>
+        /// <remarks>
+        /// Defaults to <see cref="ContentTypes.Json"/>.
+        /// This setting is required when this serializer needs to co-exist with other json serializers.
+        /// </remarks>
+        /// <param name="config">The <see cref="SerializationExtensions{T}"/> instance.</param>
+        /// <param name="contentTypeKey">The content type key to use.</param>
+        public static void ContentTypeKey(this SerializationExtensions<NewtonsoftJsonSerializer> config, string contentTypeKey)
         {
             Guard.AgainstNull(config, nameof(config));
             Guard.AgainstNullOrEmpty(contentTypeKey, nameof(contentTypeKey));

--- a/src/NServiceBus.Newtonsoft.Json/NewtonsoftJsonSerializer.cs
+++ b/src/NServiceBus.Newtonsoft.Json/NewtonsoftJsonSerializer.cs
@@ -9,16 +9,11 @@
     /// <summary>
     /// Enables Newtonsoft Json serialization.
     /// </summary>
-    public class NewtonsoftSerializer : SerializationDefinition
+    public class NewtonsoftJsonSerializer : SerializationDefinition
     {
-
         /// <summary>
         /// Provides a factory method for building a message serializer.
         /// </summary>
-        [ObsoleteEx(
-        TreatAsErrorFromVersion = "3.0",
-        RemoveInVersion = "4.0",
-        ReplacementTypeOrMember = nameof(NewtonsoftJsonSerializer))]
         public override Func<IMessageMapper, IMessageSerializer> Configure(ReadOnlySettings settings)
         {
             return mapper =>
@@ -27,7 +22,7 @@
                 var writerCreator = settings.GetWriterCreator();
                 var serializerSettings = settings.GetSettings();
                 var contentTypeKey = settings.GetContentTypeKey();
-                return new JsonMessageSerializer(mapper, readerCreator, writerCreator, serializerSettings, contentTypeKey, global::Newtonsoft.Json.TypeNameHandling.Auto);
+                return new JsonMessageSerializer(mapper, readerCreator, writerCreator, serializerSettings, contentTypeKey, global::Newtonsoft.Json.TypeNameHandling.None);
             };
         }
 

--- a/src/NServiceBus.Newtonsoft.Json/NewtonsoftSerializer.cs
+++ b/src/NServiceBus.Newtonsoft.Json/NewtonsoftSerializer.cs
@@ -18,7 +18,7 @@
 
         /// <summary>
         /// Provides a factory method for building a message serializer.
-        /// </summary>        
+        /// </summary>
         public override Func<IMessageMapper, IMessageSerializer> Configure(ReadOnlySettings settings)
         {
             return mapper =>

--- a/src/NServiceBus.Newtonsoft.Json/NewtonsoftSerializer.cs
+++ b/src/NServiceBus.Newtonsoft.Json/NewtonsoftSerializer.cs
@@ -9,16 +9,16 @@
     /// <summary>
     /// Enables Newtonsoft Json serialization.
     /// </summary>
+    [ObsoleteEx(
+    TreatAsErrorFromVersion = "3.0",
+    RemoveInVersion = "4.0",
+    ReplacementTypeOrMember = nameof(NewtonsoftJsonSerializer))]
     public class NewtonsoftSerializer : SerializationDefinition
     {
 
         /// <summary>
         /// Provides a factory method for building a message serializer.
-        /// </summary>
-        [ObsoleteEx(
-        TreatAsErrorFromVersion = "3.0",
-        RemoveInVersion = "4.0",
-        ReplacementTypeOrMember = nameof(NewtonsoftJsonSerializer))]
+        /// </summary>        
         public override Func<IMessageMapper, IMessageSerializer> Configure(ReadOnlySettings settings)
         {
             return mapper =>

--- a/src/Sample/Program.cs
+++ b/src/Sample/Program.cs
@@ -7,7 +7,7 @@ class Program
     static void Main()
     {
         var endpointConfiguration = new EndpointConfiguration("NewtonsoftSerializerSample");
-        endpointConfiguration.UseSerialization<NewtonsoftSerializer>();
+        endpointConfiguration.UseSerialization<NewtonsoftJsonSerializer>();
         endpointConfiguration.EnableInstallers();
         endpointConfiguration.UseTransport<LearningTransport>();
         endpointConfiguration.UsePersistence<InMemoryPersistence>();

--- a/src/Tests/APIApprovals.cs
+++ b/src/Tests/APIApprovals.cs
@@ -9,7 +9,7 @@ public class APIApprovals
     [Test]
     public void Approve()
     {
-        var publicApi = ApiGenerator.GeneratePublicApi(typeof(NewtonsoftSerializer).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute", "System.Reflection.AssemblyMetadataAttribute" });
+        var publicApi = ApiGenerator.GeneratePublicApi(typeof(NewtonsoftJsonSerializer).Assembly, excludeAttributes: new[] { "System.Runtime.Versioning.TargetFrameworkAttribute", "System.Reflection.AssemblyMetadataAttribute" });
         Approver.Verify(publicApi);
     }
 }

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -3,20 +3,20 @@ namespace NServiceBus
 {
     public class static NewtonsoftConfigurationExtensions
     {
-        [System.ObsoleteAttribute("Use `NewtonsoftJsonSerializer` instead. Will be treated as an error from version " +
-            "3.0.0. Will be removed in version 4.0.0.", false)]
+        [System.ObsoleteAttribute("Use the equivalent method on NewtonsoftJsonSerializer instead. Will be treated as" +
+            " an error from version 3.0.0. Will be removed in version 4.0.0.", false)]
         public static void ContentTypeKey(this NServiceBus.Serialization.SerializationExtensions<NServiceBus.NewtonsoftSerializer> config, string contentTypeKey) { }
         public static void ContentTypeKey(this NServiceBus.Serialization.SerializationExtensions<NServiceBus.NewtonsoftJsonSerializer> config, string contentTypeKey) { }
-        [System.ObsoleteAttribute("Use `NewtonsoftJsonSerializer` instead. Will be treated as an error from version " +
-            "3.0.0. Will be removed in version 4.0.0.", false)]
+        [System.ObsoleteAttribute("Use the equivalent method on NewtonsoftJsonSerializer instead. Will be treated as" +
+            " an error from version 3.0.0. Will be removed in version 4.0.0.", false)]
         public static void ReaderCreator(this NServiceBus.Serialization.SerializationExtensions<NServiceBus.NewtonsoftSerializer> config, System.Func<System.IO.Stream, Newtonsoft.Json.JsonReader> readerCreator) { }
         public static void ReaderCreator(this NServiceBus.Serialization.SerializationExtensions<NServiceBus.NewtonsoftJsonSerializer> config, System.Func<System.IO.Stream, Newtonsoft.Json.JsonReader> readerCreator) { }
-        [System.ObsoleteAttribute("Use `NewtonsoftJsonSerializer` instead. Will be treated as an error from version " +
-            "3.0.0. Will be removed in version 4.0.0.", false)]
+        [System.ObsoleteAttribute("Use the equivalent method on NewtonsoftJsonSerializer instead. Will be treated as" +
+            " an error from version 3.0.0. Will be removed in version 4.0.0.", false)]
         public static void Settings(this NServiceBus.Serialization.SerializationExtensions<NServiceBus.NewtonsoftSerializer> config, Newtonsoft.Json.JsonSerializerSettings settings) { }
         public static void Settings(this NServiceBus.Serialization.SerializationExtensions<NServiceBus.NewtonsoftJsonSerializer> config, Newtonsoft.Json.JsonSerializerSettings settings) { }
-        [System.ObsoleteAttribute("Use `NewtonsoftJsonSerializer` instead. Will be treated as an error from version " +
-            "3.0.0. Will be removed in version 4.0.0.", false)]
+        [System.ObsoleteAttribute("Use the equivalent method on NewtonsoftJsonSerializer instead. Will be treated as" +
+            " an error from version 3.0.0. Will be removed in version 4.0.0.", false)]
         public static void WriterCreator(this NServiceBus.Serialization.SerializationExtensions<NServiceBus.NewtonsoftSerializer> config, System.Func<System.IO.Stream, Newtonsoft.Json.JsonWriter> writerCreator) { }
         public static void WriterCreator(this NServiceBus.Serialization.SerializationExtensions<NServiceBus.NewtonsoftJsonSerializer> config, System.Func<System.IO.Stream, Newtonsoft.Json.JsonWriter> writerCreator) { }
     }
@@ -25,11 +25,11 @@ namespace NServiceBus
         public NewtonsoftJsonSerializer() { }
         public override System.Func<NServiceBus.MessageInterfaces.IMessageMapper, NServiceBus.Serialization.IMessageSerializer> Configure(NServiceBus.Settings.ReadOnlySettings settings) { }
     }
+    [System.ObsoleteAttribute("Use `NewtonsoftJsonSerializer` instead. Will be treated as an error from version " +
+        "3.0.0. Will be removed in version 4.0.0.", false)]
     public class NewtonsoftSerializer : NServiceBus.Serialization.SerializationDefinition
     {
         public NewtonsoftSerializer() { }
-        [System.ObsoleteAttribute("Use `NewtonsoftJsonSerializer` instead. Will be treated as an error from version " +
-            "3.0.0. Will be removed in version 4.0.0.", false)]
         public override System.Func<NServiceBus.MessageInterfaces.IMessageMapper, NServiceBus.Serialization.IMessageSerializer> Configure(NServiceBus.Settings.ReadOnlySettings settings) { }
     }
 }

--- a/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
+++ b/src/Tests/ApprovalFiles/APIApprovals.Approve.approved.txt
@@ -3,14 +3,33 @@ namespace NServiceBus
 {
     public class static NewtonsoftConfigurationExtensions
     {
+        [System.ObsoleteAttribute("Use `NewtonsoftJsonSerializer` instead. Will be treated as an error from version " +
+            "3.0.0. Will be removed in version 4.0.0.", false)]
         public static void ContentTypeKey(this NServiceBus.Serialization.SerializationExtensions<NServiceBus.NewtonsoftSerializer> config, string contentTypeKey) { }
+        public static void ContentTypeKey(this NServiceBus.Serialization.SerializationExtensions<NServiceBus.NewtonsoftJsonSerializer> config, string contentTypeKey) { }
+        [System.ObsoleteAttribute("Use `NewtonsoftJsonSerializer` instead. Will be treated as an error from version " +
+            "3.0.0. Will be removed in version 4.0.0.", false)]
         public static void ReaderCreator(this NServiceBus.Serialization.SerializationExtensions<NServiceBus.NewtonsoftSerializer> config, System.Func<System.IO.Stream, Newtonsoft.Json.JsonReader> readerCreator) { }
+        public static void ReaderCreator(this NServiceBus.Serialization.SerializationExtensions<NServiceBus.NewtonsoftJsonSerializer> config, System.Func<System.IO.Stream, Newtonsoft.Json.JsonReader> readerCreator) { }
+        [System.ObsoleteAttribute("Use `NewtonsoftJsonSerializer` instead. Will be treated as an error from version " +
+            "3.0.0. Will be removed in version 4.0.0.", false)]
         public static void Settings(this NServiceBus.Serialization.SerializationExtensions<NServiceBus.NewtonsoftSerializer> config, Newtonsoft.Json.JsonSerializerSettings settings) { }
+        public static void Settings(this NServiceBus.Serialization.SerializationExtensions<NServiceBus.NewtonsoftJsonSerializer> config, Newtonsoft.Json.JsonSerializerSettings settings) { }
+        [System.ObsoleteAttribute("Use `NewtonsoftJsonSerializer` instead. Will be treated as an error from version " +
+            "3.0.0. Will be removed in version 4.0.0.", false)]
         public static void WriterCreator(this NServiceBus.Serialization.SerializationExtensions<NServiceBus.NewtonsoftSerializer> config, System.Func<System.IO.Stream, Newtonsoft.Json.JsonWriter> writerCreator) { }
+        public static void WriterCreator(this NServiceBus.Serialization.SerializationExtensions<NServiceBus.NewtonsoftJsonSerializer> config, System.Func<System.IO.Stream, Newtonsoft.Json.JsonWriter> writerCreator) { }
+    }
+    public class NewtonsoftJsonSerializer : NServiceBus.Serialization.SerializationDefinition
+    {
+        public NewtonsoftJsonSerializer() { }
+        public override System.Func<NServiceBus.MessageInterfaces.IMessageMapper, NServiceBus.Serialization.IMessageSerializer> Configure(NServiceBus.Settings.ReadOnlySettings settings) { }
     }
     public class NewtonsoftSerializer : NServiceBus.Serialization.SerializationDefinition
     {
         public NewtonsoftSerializer() { }
+        [System.ObsoleteAttribute("Use `NewtonsoftJsonSerializer` instead. Will be treated as an error from version " +
+            "3.0.0. Will be removed in version 4.0.0.", false)]
         public override System.Func<NServiceBus.MessageInterfaces.IMessageMapper, NServiceBus.Serialization.IMessageSerializer> Configure(NServiceBus.Settings.ReadOnlySettings settings) { }
     }
 }

--- a/src/Tests/ArrayTests.cs
+++ b/src/Tests/ArrayTests.cs
@@ -13,7 +13,9 @@ public class ArrayTests
     string typeName = $"{typeof(ArrayMessage).FullName}, {typeof(ArrayMessage).Assembly.GetName().Name}";
 
     [Test]
-    public void Should_throw_for_multiple_dollar()
+    [TestCase(Newtonsoft.Json.TypeNameHandling.Auto)]
+    [TestCase(Newtonsoft.Json.TypeNameHandling.None)]
+    public void Should_throw_for_multiple_dollar(Newtonsoft.Json.TypeNameHandling typeNameHandling)
     {
         var text = $@"
 [{{
@@ -30,14 +32,16 @@ public class ArrayTests
             WriteToStream(stream, text);
 
             var messageMapper = new MessageMapper();
-            var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null);
+            var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null, typeNameHandling);
             var exception = Assert.Throws<Exception>(() => serializer.Deserialize(stream, new List<Type>()));
             Approver.Verify(exception.Message);
         }
     }
 
     [Test]
-    public void Should_throw_for_multiple_passed_type()
+    [TestCase(Newtonsoft.Json.TypeNameHandling.Auto)]
+    [TestCase(Newtonsoft.Json.TypeNameHandling.None)]
+    public void Should_throw_for_multiple_passed_type(Newtonsoft.Json.TypeNameHandling typeNameHandling)
     {
         var text = @"
 [{
@@ -52,7 +56,7 @@ public class ArrayTests
             WriteToStream(stream, text);
 
             var messageMapper = new MessageMapper();
-            var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null);
+            var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null, typeNameHandling);
             var messageTypes = new List<Type>
             {
                 typeof(ArrayMessage)
@@ -66,7 +70,9 @@ public class ArrayTests
     }
 
     [Test]
-    public void Should_not_throw_for_single_dollar()
+    [TestCase(Newtonsoft.Json.TypeNameHandling.Auto)]
+    [TestCase(Newtonsoft.Json.TypeNameHandling.None)]
+    public void Should_not_throw_for_single_dollar(Newtonsoft.Json.TypeNameHandling typeNameHandling)
     {
         var text = $@"
 [{{
@@ -79,7 +85,7 @@ public class ArrayTests
             WriteToStream(stream, text);
 
             var messageMapper = new MessageMapper();
-            var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null);
+            var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null, typeNameHandling);
             var deserialize = serializer.Deserialize(stream, new List<Type>());
             Approver.Verify(deserialize.Single());
         }
@@ -87,7 +93,9 @@ public class ArrayTests
 
 
     [Test]
-    public void Should_not_throw_for_single_passed_type()
+    [TestCase(Newtonsoft.Json.TypeNameHandling.Auto)]
+    [TestCase(Newtonsoft.Json.TypeNameHandling.None)]
+    public void Should_not_throw_for_single_passed_type(Newtonsoft.Json.TypeNameHandling typeNameHandling)
     {
         var text = @"
 [{
@@ -99,7 +107,7 @@ public class ArrayTests
             WriteToStream(stream, text);
 
             var messageMapper = new MessageMapper();
-            var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null);
+            var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null, typeNameHandling);
             var messageTypes = new List<Type>
             {
                 typeof(ArrayMessage)

--- a/src/Tests/Private_with_two_unrelated_interface_without_wrapping.cs
+++ b/src/Tests/Private_with_two_unrelated_interface_without_wrapping.cs
@@ -8,7 +8,9 @@ public class Private_with_two_unrelated_interface_without_wrapping
 {
 
     [Test]
-    public void Run()
+    [TestCase(Newtonsoft.Json.TypeNameHandling.Auto)]
+    [TestCase(Newtonsoft.Json.TypeNameHandling.None)]
+    public void Run(Newtonsoft.Json.TypeNameHandling typeNameHandling)
     {
         var messageMapper = new MessageMapper();
         var messageTypes = new[]
@@ -17,7 +19,7 @@ public class Private_with_two_unrelated_interface_without_wrapping
             typeof(IMyEventB)
         };
         messageMapper.Initialize(messageTypes);
-        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null);
+        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null, typeNameHandling);
 
         var message = new CompositeMessage
         {

--- a/src/Tests/TypeNameHandlingTests.cs
+++ b/src/Tests/TypeNameHandlingTests.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Collections.Generic;
+using System.IO;
+using NServiceBus.MessageInterfaces.MessageMapper.Reflection;
+using NServiceBus.Newtonsoft.Json;
+using NUnit.Framework;
+
+[TestFixture]
+public class TypeNameHandlingTests
+{
+    string typeName = $"{typeof(TestMessage).FullName}, {typeof(TestMessage).Assembly.GetName().Name}";
+
+    [Test]
+    public void Should_not_recognise_type_with_none()
+    {
+        var text = $@"
+{{
+    $type: '{typeName}',
+    SomeProperty: 'Value1'
+}}";
+
+        using (var stream = new MemoryStream())
+        {
+            WriteToStream(stream, text);
+
+            var messageMapper = new MessageMapper();
+            var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null);
+            var result = serializer.Deserialize(stream, new List<Type>());
+            Assert.IsNotInstanceOf<TestMessage>(result[0]);
+        }
+    }
+
+
+    [Test]
+    public void Should_recognise_type_with_auto()
+    {
+        var text = $@"
+{{
+    $type: '{typeName}',
+    SomeProperty: 'Value1'
+}}";
+
+        using (var stream = new MemoryStream())
+        {
+            WriteToStream(stream, text);
+
+            var messageMapper = new MessageMapper();
+            var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null, Newtonsoft.Json.TypeNameHandling.Auto);
+            var result = serializer.Deserialize(stream, new List<Type>());
+            Assert.That(result[0], Is.TypeOf(typeof(TestMessage)));
+            Assert.IsInstanceOf<TestMessage>(result[0]);
+        }
+    }
+
+    static void WriteToStream(MemoryStream stream, string text)
+    {
+        var streamWriter = new StreamWriter(stream);
+        streamWriter.Write(text);
+        streamWriter.Flush();
+        stream.Position = 0;
+    }
+
+    public class TestMessage
+    {
+        public string SomeProperty { get; set; }
+    }
+}

--- a/src/Tests/When_deserializing_a_message.cs
+++ b/src/Tests/When_deserializing_a_message.cs
@@ -10,10 +10,12 @@ public class When_deserializing_a_message
 {
 
     [Test]
-    public void Should_handle_message_with_UTF8_BOM()
+    [TestCase(Newtonsoft.Json.TypeNameHandling.Auto)]
+    [TestCase(Newtonsoft.Json.TypeNameHandling.None)]
+    public void Should_handle_message_with_UTF8_BOM(Newtonsoft.Json.TypeNameHandling typeNameHandling)
     {
         var messageMapper = new MessageMapper();
-        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null);
+        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null, typeNameHandling);
 
         var utf8WithBomEncoding = new UTF8Encoding(true);
         var serialized = utf8WithBomEncoding
@@ -32,10 +34,12 @@ public class When_deserializing_a_message
     }
 
     [Test]
-    public void Should_handle_message_without_UTF8_BOM()
+    [TestCase(Newtonsoft.Json.TypeNameHandling.Auto)]
+    [TestCase(Newtonsoft.Json.TypeNameHandling.None)]
+    public void Should_handle_message_without_UTF8_BOM(Newtonsoft.Json.TypeNameHandling typeNameHandling)
     {
         var messageMapper = new MessageMapper();
-        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null);
+        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null, typeNameHandling);
 
         var utf8WithoutBomEncoding = new UTF8Encoding(false);
         var serialized = utf8WithoutBomEncoding

--- a/src/Tests/When_serializing_a_message.cs
+++ b/src/Tests/When_serializing_a_message.cs
@@ -10,10 +10,12 @@ using NUnit.Framework;
 public class When_serializing_a_message
 {
     [Test]
-    public void Should_emit_UTF8_BOM_by_default()
+    [TestCase(TypeNameHandling.Auto)]
+    [TestCase(TypeNameHandling.None)]
+    public void Should_emit_UTF8_BOM_by_default(TypeNameHandling typeNameHandling)
     {
         var messageMapper = new MessageMapper();
-        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null);
+        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null, typeNameHandling);
         var message = new SimpleMessage();
         using (var stream = new MemoryStream())
         {
@@ -32,7 +34,9 @@ public class When_serializing_a_message
     }
 
     [Test]
-    public void Should_not_emit_UTF8_BOM_if_configured_not_to()
+    [TestCase(TypeNameHandling.Auto)]
+    [TestCase(TypeNameHandling.None)]
+    public void Should_not_emit_UTF8_BOM_if_configured_not_to(TypeNameHandling typeNameHandling)
     {
         var messageMapper = new MessageMapper();
 
@@ -45,7 +49,7 @@ public class When_serializing_a_message
             };
         };
 
-        var serializer = new JsonMessageSerializer(messageMapper, null, writerCreator, null, null);
+        var serializer = new JsonMessageSerializer(messageMapper, null, writerCreator, null, null, typeNameHandling);
 
         var message = new SimpleMessage();
         using (var stream = new MemoryStream())

--- a/src/Tests/With_base_but_without_concrete.cs
+++ b/src/Tests/With_base_but_without_concrete.cs
@@ -9,10 +9,12 @@ using NUnit.Framework;
 public class With_base_type_but_without_sub_type_in_message_types
 {
     [Test]
-    public void Deserialize()
+    [TestCase(Newtonsoft.Json.TypeNameHandling.Auto)]
+    [TestCase(Newtonsoft.Json.TypeNameHandling.None)]
+    public void Deserialize(Newtonsoft.Json.TypeNameHandling typeNameHandling)
     {
         var messageMapper = new MessageMapper();
-        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null);
+        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null, typeNameHandling);
         var messageTypes = new[]
         {
             typeof(ISomeBaseMessage)

--- a/src/Tests/With_concrete_implementation_and_interface.cs
+++ b/src/Tests/With_concrete_implementation_and_interface.cs
@@ -9,7 +9,9 @@ public class With_concrete_implementation_and_interface
 {
 
     [Test]
-    public void Run()
+    [TestCase(Newtonsoft.Json.TypeNameHandling.Auto)]
+    [TestCase(Newtonsoft.Json.TypeNameHandling.None)]
+    public void Run(Newtonsoft.Json.TypeNameHandling typeNameHandling)
     {
         var map = new[]
         {
@@ -18,7 +20,7 @@ public class With_concrete_implementation_and_interface
         };
         var messageMapper = new MessageMapper();
         messageMapper.Initialize(map);
-        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null);
+        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null, typeNameHandling);
 
         var message = new SuperMessageWithConcreteImpl
         {

--- a/src/Tests/With_interface_without_wrapping.cs
+++ b/src/Tests/With_interface_without_wrapping.cs
@@ -7,10 +7,12 @@ using NUnit.Framework;
 public class With_interface_without_wrapping
 {
     [Test]
-    public void Run()
+    [TestCase(Newtonsoft.Json.TypeNameHandling.Auto)]
+    [TestCase(Newtonsoft.Json.TypeNameHandling.None)]
+    public void Run(Newtonsoft.Json.TypeNameHandling typeNameHandling)
     {
         var messageMapper = new MessageMapper();
-        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null);
+        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null, typeNameHandling);
         var message = new SuperMessage { SomeProperty = "John" };
         using (var stream = new MemoryStream())
         {

--- a/src/Tests/Without_concrete_implementation_and_interface.cs
+++ b/src/Tests/Without_concrete_implementation_and_interface.cs
@@ -8,7 +8,9 @@ using Particular.Approvals;
 public class Without_concrete_implementation_and_interface
 {
     [Test]
-    public void Serialize()
+    [TestCase(Newtonsoft.Json.TypeNameHandling.Auto)]
+    [TestCase(Newtonsoft.Json.TypeNameHandling.None)]
+    public void Serialize(Newtonsoft.Json.TypeNameHandling typeNameHandling)
     {
         var messageMapper = new MessageMapper();
         var types = new[]
@@ -16,7 +18,7 @@ public class Without_concrete_implementation_and_interface
             typeof(IWithoutConcrete)
         };
         messageMapper.Initialize(types);
-        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null);
+        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null, typeNameHandling);
 
         var message = messageMapper.CreateInstance<IWithoutConcrete>();
         using (var stream = new MemoryStream())
@@ -30,7 +32,9 @@ public class Without_concrete_implementation_and_interface
     }
 
     [Test]
-    public void Deserialize()
+    [TestCase(Newtonsoft.Json.TypeNameHandling.Auto)]
+    [TestCase(Newtonsoft.Json.TypeNameHandling.None)]
+    public void Deserialize(Newtonsoft.Json.TypeNameHandling typeNameHandling)
     {
         var messageMapper = new MessageMapper();
         var messageTypes = new[]
@@ -38,7 +42,7 @@ public class Without_concrete_implementation_and_interface
             typeof(IWithoutConcrete)
         };
         messageMapper.Initialize(messageTypes);
-        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null);
+        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null, typeNameHandling);
 
         var message = messageMapper.CreateInstance<IWithoutConcrete>();
         message.SomeProperty = "test";

--- a/src/Tests/Without_typeInfo.cs
+++ b/src/Tests/Without_typeInfo.cs
@@ -8,10 +8,12 @@ public class Without_typeInfo
 {
 
     [Test]
-    public void Run()
+    [TestCase(Newtonsoft.Json.TypeNameHandling.Auto)]
+    [TestCase(Newtonsoft.Json.TypeNameHandling.None)]
+    public void Run(Newtonsoft.Json.TypeNameHandling typeNameHandling)
     {
         var messageMapper = new MessageMapper();
-        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null);
+        var serializer = new JsonMessageSerializer(messageMapper, null, null, null, null, typeNameHandling);
         var message = new SimpleMessage();
         using (var stream = new MemoryStream())
         {


### PR DESCRIPTION
- Closes #184 

* added new serialiser: NewtonsoftJsonSerializer
* marked old serialiser as obsolete
* added tests for TypeNameHandling of Auto vs None
* adjusted tests to cover both TypeNameHandling types

Since the changes between 2.4 and 3 were quite different (v3 didn't need the old serialiser to be tested or have any implementation) we did not cherry pick but implemented them separately.