### PR TITLE
Avoid exposing Newtonsoft.Json Nuget package reference to projects using NServiceBus.Newtonsoft.Json

### DIFF
--- a/src/NServiceBus.Newtonsoft.Json/NServiceBus.Newtonsoft.Json.csproj
+++ b/src/NServiceBus.Newtonsoft.Json/NServiceBus.Newtonsoft.Json.csproj
@@ -11,7 +11,7 @@
   <ItemGroup>    
     <PackageReference Include="Fody" Version="6.6.4" PrivateAssets="All" />    
     <PackageReference Include="Obsolete.Fody" Version="5.3.0" PrivateAssets="All" />
-    <PackageReference Include="Newtonsoft.Json" Version="[13.0.1, 14.0.0)" />
+    <PackageReference Include="Newtonsoft.Json" Version="[13.0.1, 14.0.0)" PrivateAssets="All" />
     <PackageReference Include="NServiceBus" Version="[8.0.0, 9.0.0)" />
     <PackageReference Include="Particular.Packaging" Version="2.3.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
At the moment we are facing some issues with our Azure Function App and other projects, where we need to use different/newer versions of Newtonsoft.Json Nuget package.
Can NServiceBus.Newtonsoft.Json be setup to not expose Newtonsoft.Json as a transitive dependency?
This PR/code change should take care of that by adding `PrivateAssets="All"` flag to the package reference. See also: https://learn.microsoft.com/en-us/nuget/consume-packages/package-references-in-project-files#controlling-dependency-assets