### PR TITLE
Update JsonMessageSerializer.cs

### DIFF
--- a/src/NServiceBus.Newtonsoft.Json/JsonMessageSerializer.cs
+++ b/src/NServiceBus.Newtonsoft.Json/JsonMessageSerializer.cs
@@ -70,7 +70,7 @@
             using (var writer = writerCreator(stream))
             {
                 writer.CloseOutput = false;
-                if(TryGetJsonConverter(message.GetType(), out var converter))
+                if(TryGetJsonConverter(message.GetType(), out var converter) && converter.CanWrite)
                 {
                     converter.WriteJson(writer, message, jsonSerializer);
                 }
@@ -105,7 +105,7 @@
             {
                 reader.CloseInput = false;
 
-                if (TryGetJsonConverter(type, out var converter))
+                if (TryGetJsonConverter(type, out var converter) && converter.CanRead)
                 {
                     return converter.ReadJson(reader, type, null, jsonSerializer);
                 }


### PR DESCRIPTION
when specifying a wrapper message type for an array, isArrayStream logic prevents the specified json converter from deserializing the array into a wrapped message.