### PR TITLE
Add support for NServiceBus.ClaimCheck properties

### DIFF
--- a/src/NServiceBus.Newtonsoft.Json/ClaimCheckPropertyConverter.cs
+++ b/src/NServiceBus.Newtonsoft.Json/ClaimCheckPropertyConverter.cs
@@ -1,0 +1,26 @@
+﻿namespace NServiceBus.Newtonsoft.Json
+{
+    using System;
+    using global::Newtonsoft.Json;
+
+    class ClaimCheckPropertyConverter : JsonConverter
+    {
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            dynamic dynamicValue = value;
+
+            writer.WriteStartObject();
+            writer.WritePropertyName(nameof(dynamicValue.Key));
+            writer.WriteValue(dynamicValue.Key);
+            writer.WritePropertyName(nameof(dynamicValue.HasValue));
+            writer.WriteValue(dynamicValue.HasValue);
+            writer.WriteEndObject();
+        }
+
+        public override bool CanConvert(Type objectType) => objectType.Name.Equals("ClaimCheckProperty`1", StringComparison.Ordinal);
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer) => throw new NotImplementedException();
+
+        public override bool CanRead => false;
+    }
+}

--- a/src/NServiceBus.Newtonsoft.Json/DataBusPropertyConverter.cs
+++ b/src/NServiceBus.Newtonsoft.Json/DataBusPropertyConverter.cs
@@ -3,9 +3,11 @@
     using System;
     using global::Newtonsoft.Json;
 
-    class DataBusPropertyConverter : JsonConverter<IClaimCheckProperty>
+#pragma warning disable CS0618 // Type or member is obsolete
+    class DataBusPropertyConverter : JsonConverter<IDataBusProperty>
+
     {
-        public override void WriteJson(JsonWriter writer, IClaimCheckProperty value, JsonSerializer serializer)
+        public override void WriteJson(JsonWriter writer, IDataBusProperty value, JsonSerializer serializer)
         {
             writer.WriteStartObject();
             writer.WritePropertyName(nameof(value.Key));
@@ -15,8 +17,9 @@
             writer.WriteEndObject();
         }
 
-        public override IClaimCheckProperty ReadJson(JsonReader reader, Type objectType, IClaimCheckProperty existingValue, bool hasExistingValue, JsonSerializer serializer) => throw new NotImplementedException();
+        public override IDataBusProperty ReadJson(JsonReader reader, Type objectType, IDataBusProperty existingValue, bool hasExistingValue, JsonSerializer serializer) => throw new NotImplementedException();
 
         public override bool CanRead => false;
     }
+#pragma warning restore CS0618 // Type or member is obsolete
 }

--- a/src/NServiceBus.Newtonsoft.Json/JsonMessageSerializer.cs
+++ b/src/NServiceBus.Newtonsoft.Json/JsonMessageSerializer.cs
@@ -33,6 +33,7 @@
             };
 
             settings.Converters.Add(new DataBusPropertyConverter());
+            settings.Converters.Add(new ClaimCheckPropertyConverter());
 
             if (settings.TypeNameHandling == TypeNameHandling.Auto)
             {

--- a/src/NServiceBus.Newtonsoft.Json/NServiceBus.Newtonsoft.Json.csproj
+++ b/src/NServiceBus.Newtonsoft.Json/NServiceBus.Newtonsoft.Json.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
     <PackageReference Include="NServiceBus" Version="9.2.6" />
-    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.0.1" />
+
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Tests/Tests.csproj
+++ b/src/Tests/Tests.csproj
@@ -20,6 +20,7 @@
 
   <ItemGroup>
     <PackageReference Include="NServiceBus.AcceptanceTests.Sources" Version="9.2.6" GeneratePathProperty="true" />
+    <PackageReference Include="NServiceBus.ClaimCheck" Version="1.0.1" />
     <PackageReference Include="Particular.Approvals" Version="2.0.1" />
     <PackageReference Include="PublicApiGenerator" Version="11.4.5" />
   </ItemGroup>


### PR DESCRIPTION
This PR introduces changes that allow the serializer to be used when endpoints are also using the NServiceBus.ClaimCheck package.

- The `DataBusPropertyConverter` class that was improperly modified in #534 has been reverted to its original form. We need to keep this class around until the original DataBus implementation is removed from the NServiceBus core assembly.
- A new `ClaimCheckPropertyConverter` class has been added that properly serializes the [`ClaimCheckProperty`](https://github.com/Particular/NServiceBus.ClaimCheck/blob/master/src/NServiceBus.ClaimCheck/ClaimCheckProperty.cs) class.